### PR TITLE
Add Auto-Paste from Output Buffer

### DIFF
--- a/lua/mongoscripting.lua
+++ b/lua/mongoscripting.lua
@@ -150,6 +150,8 @@ function M.run_buffer()
   vim.fn.setreg(Config.output_register, res)
   if L.mongosh_window ~= nil then
     update_ui()
+  else
+    vim.cmd(':normal "' .. Config.output_register .. "p")
   end
 end
 
@@ -167,6 +169,8 @@ function M.run_selection()
   vim.fn.setreg(Config.output_register, res)
   if L.mongosh_window ~= nil then
     update_ui()
+  else
+    vim.cmd(':normal "' .. Config.output_register .. "p")
   end
 end
 


### PR DESCRIPTION
This commit adds auto-paste of the results of a run when the UI buffer is hidden.

The mongosh output will be pasted on the line following the current cursor position.

If the UI window is open, then we don't auto-paste, and the UI will still be updated with the latest run results when toggling it open even if they were auto-pasted.